### PR TITLE
support multiple S3 website name formats

### DIFF
--- a/lambda_code/scan/scan.py
+++ b/lambda_code/scan/scan.py
@@ -230,7 +230,7 @@ def cname_s3(account_name, record_sets):
         if r["Type"] in ["CNAME"]
         and "ResourceRecords" in r
         and "amazonaws.com" in r["ResourceRecords"][0]["Value"]
-        and ".s3-website." in r["ResourceRecords"][0]["Value"]
+        and ".s3-website" in r["ResourceRecords"][0]["Value"]
     ]
 
     for record in record_sets_filtered:


### PR DESCRIPTION
there are two possible DNS formats for S3 website CNAMEs:
- test.example.com.s3-website.eu-west-1.amazonaws.com
- test.example.com.s3-website-eu-west-1.amazonaws.com
only the first of these is currently detected

This PR fixes the issue