### PR TITLE
updated to use pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     -   id: check-merge-conflict
     -   id: check-vcs-permalinks
     -   id: check-yaml
+        exclude: ^(\.config/|lambda_code/takeover/)
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -35,18 +36,19 @@ repos:
     rev: 22.12.0
     hooks:
     -   id: black
-        args: [--check,--line-length=120]
+        args: [--line-length=120]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/pycqa/bandit
+    rev: 1.7.4
+    hooks:
+    -   id: bandit
         exclude: .\.tf | ^\.github/
 -   repo: https://github.com/pycqa/prospector
     rev: v1.8.4
     hooks:
     -   id: prospector
-        additional_dependencies:
-        - ".[with_mypy,with_bandit]"
-        args: [
-        '--with-tool=mypy',
-        '--with-tool=bandit',
-        ]
+        args:
+          - --zero-exit
         exclude: .\.tf | ^\.github/
 -   repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+default_language_version:
+    # force all unspecified python hooks to run python3
+    python: python3
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: check-docstring-first
+    -   id: check-executables-have-shebangs
+    -   id: check-merge-conflict
+    -   id: check-vcs-permalinks
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py36-plus]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.1.0
+    hooks:
+    -   id: add-trailing-comma
+        args: [--py36-plus]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: [--py3-plus]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+    -   id: black
+        args: [--check,--line-length=120]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/pycqa/prospector
+    rev: v1.8.4
+    hooks:
+    -   id: prospector
+        additional_dependencies:
+        - ".[with_mypy,with_bandit]"
+        args: [
+        '--with-tool=mypy',
+        '--with-tool=bandit',
+        ]
+        exclude: .\.tf | ^\.github/
+-   repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.0
+    hooks:
+    -   id: terraform_fmt
+    -   id: terraform_checkov
+        args:
+          - --args=--config-file=.config/sast_terraform_checkov_json.yml
+        exclude: .\.py | ^\.github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_language_version:
     # force all unspecified python hooks to run python3
     python: python3
+exclude: ^build/
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1


### PR DESCRIPTION
When I tried to save a file with my IDE, it always changes the file unexpectedly. I think we need to standardize on the format of python code. [Pre-commit ](https://pre-commit.com/) is one of those solutions. It will format the code using standard tools like flake8 or autopep8. We dont need to create a hook before doing the commit at the moment as pre-commit can be run as needed. After the coding session, contributor can just run the `pre-commit` command

An example of a repo that used pre-commit is [cartography](https://github.com/lyft/cartography)

You can install pre-commit with:

```bash
brew install pre-commit
```

Pre-commit can be run manually with in the folder

```bash
pre-commit run --files ./[folder_name]/*
```

Example:

```bash
pre-commit run --files ./utils/*
```

I already ran pre-commit on utils folder.