### PR TITLE
secret manager for slack url

### DIFF
--- a/aws-iam-policies/domain-protect-audit.json
+++ b/aws-iam-policies/domain-protect-audit.json
@@ -13,6 +13,16 @@
         "route53domains:ListDomains"
       ]
     },
+	{
+	  "Sid": "DomainProtectSecret",
+	  "Effect": "Allow",
+	  "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*",
+	  "Action": [
+		"secretsmanager:GetSecretValue",
+		"secretsmanager:DescribeSecret",
+		"secretsmanager:ListSecretVersionIds"
+	  ]
+	},
     {
       "Sid": "DomainProtectIPs",
       "Effect": "Allow",

--- a/aws-iam-policies/domain-protect-audit.json
+++ b/aws-iam-policies/domain-protect-audit.json
@@ -13,16 +13,6 @@
         "route53domains:ListDomains"
       ]
     },
-	{
-	  "Sid": "DomainProtectSecret",
-	  "Effect": "Allow",
-	  "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*",
-	  "Action": [
-		"secretsmanager:GetSecretValue",
-		"secretsmanager:DescribeSecret",
-		"secretsmanager:ListSecretVersionIds"
-	  ]
-	},
     {
       "Sid": "DomainProtectIPs",
       "Effect": "Allow",

--- a/aws-iam-policies/domain-protect-deploy.json
+++ b/aws-iam-policies/domain-protect-deploy.json
@@ -135,6 +135,21 @@
       ],
       "Resource": "arn:aws:sns:eu-west-1:SECURITY_AWS_ACCOUNT_ID:domain-protect-*"
     },
+	{
+	  "Effect": "Allow",
+	  "Action": [
+		"secretsmanager:PutResourcePolicy",
+		"secretsmanager:DeleteResourcePolicy",
+		"secretsmanager:RestoreSecret",
+		"secretsmanager:PutSecretValue",
+		"secretsmanager:CreateSecret",
+		"secretsmanager:UpdateSecretVersionStage",
+		"secretsmanager:DeleteSecret",
+		"secretsmanager:RotateSecret",
+		"secretsmanager:UpdateSecret"
+	  ],
+	  "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*"
+	},
     {
       "Effect": "Allow",
       "Action": [

--- a/aws-iam-policies/domain-protect-deploy.json
+++ b/aws-iam-policies/domain-protect-deploy.json
@@ -135,21 +135,21 @@
       ],
       "Resource": "arn:aws:sns:eu-west-1:SECURITY_AWS_ACCOUNT_ID:domain-protect-*"
     },
-	{
-	  "Effect": "Allow",
-	  "Action": [
-		"secretsmanager:PutResourcePolicy",
-		"secretsmanager:DeleteResourcePolicy",
-		"secretsmanager:RestoreSecret",
-		"secretsmanager:PutSecretValue",
-		"secretsmanager:CreateSecret",
-		"secretsmanager:UpdateSecretVersionStage",
-		"secretsmanager:DeleteSecret",
-		"secretsmanager:RotateSecret",
-		"secretsmanager:UpdateSecret"
-	  ],
-	  "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*"
-	},
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:PutResourcePolicy",
+        "secretsmanager:DeleteResourcePolicy",
+        "secretsmanager:RestoreSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:UpdateSecretVersionStage",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:RotateSecret",
+        "secretsmanager:UpdateSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*"
+    },
     {
       "Effect": "Allow",
       "Action": [

--- a/lambda_code/notify/notify.py
+++ b/lambda_code/notify/notify.py
@@ -4,7 +4,7 @@ import os
 
 import requests
 
-from utils.utils_aws import get_secret_value
+from utils.utils_aws import get_secret_manager_value
 from utils.utils_dates import calc_prev_month_start
 from utils.utils_globalvars import requests_timeout
 
@@ -326,7 +326,7 @@ def monthly_stats_message(json_data):
 def lambda_handler(event, context):  # pylint:disable=unused-argument
 
     try:
-        slack_url = get_secret_value("SLACK_WEBHOOK_URL_SECRET_ID")
+        slack_url = get_secret_manager_value("SLACK_WEBHOOK_URL_SECRET_ID")
     except Exception as e:
         raise e
 

--- a/lambda_code/notify/notify.py
+++ b/lambda_code/notify/notify.py
@@ -326,7 +326,7 @@ def monthly_stats_message(json_data):
 def lambda_handler(event, context):  # pylint:disable=unused-argument
 
     try:
-        slack_url = get_secret_value("SLACK_WEBHOOK_URL_SECRET_ARN")
+        slack_url = get_secret_value("SLACK_WEBHOOK_URL_SECRET_ID")
     except Exception as e:
         raise e
 

--- a/lambda_code/notify/notify.py
+++ b/lambda_code/notify/notify.py
@@ -4,11 +4,10 @@ import os
 
 import requests
 
+from utils.utils_aws import get_secret_value
 from utils.utils_dates import calc_prev_month_start
 from utils.utils_globalvars import requests_timeout
 
-
-slack_url = os.environ["SLACK_WEBHOOK_URL"]
 slack_channel = os.environ["SLACK_CHANNEL"]
 slack_webhook_type = os.environ["SLACK_WEBHOOK_TYPE"]
 slack_username = os.environ["SLACK_USERNAME"]
@@ -325,6 +324,11 @@ def monthly_stats_message(json_data):
 
 
 def lambda_handler(event, context):  # pylint:disable=unused-argument
+
+    try:
+        slack_url = get_secret_value("SLACK_WEBHOOK_URL_SECRET_ARN")
+    except Exception as e:
+        raise e
 
     slack_message = {}
     subject = event["Records"][0]["Sns"]["Subject"]

--- a/main.tf
+++ b/main.tf
@@ -12,22 +12,34 @@ module "lambda-role" {
   kms_arn                  = module.kms.kms_arn
 }
 
+module "secret-slack" {
+  source                   = "./terraform-modules/secret-manager"
+  manual_secret_upload     = var.manual_secret_upload
+  project                  = var.project
+  secret_type              = "slack webhooks"
+  secret_values            = local.env == "dev" && length(var.slack_webhook_urls_dev) > 0 ? var.slack_webhook_urls_dev : var.slack_webhook_urls
+  recovery_windows_in_days = 7
+  kms_arn                  = module.kms.kms_arn
+  tags                     = null
+}
+
+
 module "lambda-slack" {
-  source             = "./terraform-modules/lambda-slack"
-  runtime            = var.runtime
-  memory_size        = var.memory_size_slack
-  project            = var.project
-  lambda_role_arn    = module.lambda-role.lambda_role_arn
-  kms_arn            = module.kms.kms_arn
-  sns_topic_arn      = module.sns.sns_topic_arn
-  dlq_sns_topic_arn  = module.sns-dead-letter-queue.sns_topic_arn
-  slack_channels     = local.env == "dev" ? var.slack_channels_dev : var.slack_channels
-  slack_webhook_urls = local.env == "dev" && length(var.slack_webhook_urls_dev) > 0 ? var.slack_webhook_urls_dev : var.slack_webhook_urls
-  slack_webhook_type = var.slack_webhook_type
-  slack_emoji        = var.slack_emoji
-  slack_fix_emoji    = var.slack_fix_emoji
-  slack_new_emoji    = var.slack_new_emoji
-  slack_username     = var.slack_username
+  source                        = "./terraform-modules/lambda-slack"
+  runtime                       = var.runtime
+  memory_size                   = var.memory_size_slack
+  project                       = var.project
+  lambda_role_arn               = module.lambda-role.lambda_role_arn
+  kms_arn                       = module.kms.kms_arn
+  sns_topic_arn                 = module.sns.sns_topic_arn
+  dlq_sns_topic_arn             = module.sns-dead-letter-queue.sns_topic_arn
+  slack_channels                = local.env == "dev" ? var.slack_channels_dev : var.slack_channels
+  slack_webhook_urls_secret_ids = module.secret-slack.ids
+  slack_webhook_type            = var.slack_webhook_type
+  slack_emoji                   = var.slack_emoji
+  slack_fix_emoji               = var.slack_fix_emoji
+  slack_new_emoji               = var.slack_new_emoji
+  slack_username                = var.slack_username
 }
 
 module "lambda" {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ prospector==1.8.4
 pytest==7.1.2
 pytest-cov==3.0.0
 assertpy==1.1
-moto[sts, iam]==3.1.16
+moto[sts, iam, secretsmanager]==3.1.16
 requests-mock==1.9.3
 checkov==2.2.330

--- a/terraform-modules/iam/templates/lambda_policy.json.tpl
+++ b/terraform-modules/iam/templates/lambda_policy.json.tpl
@@ -65,5 +65,15 @@
         "${ddb_ip_table_arn}"
       ]
     }
+    {
+      "Sid": "DomainProtectSecret",
+      "Effect": "Allow",
+      "Resource": "arn:aws:secretsmanager:*:*:secret:domain-protect*",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecretVersionIds"
+      ]
+    }
   ]
 }

--- a/terraform-modules/lambda-slack/main.tf
+++ b/terraform-modules/lambda-slack/main.tf
@@ -43,14 +43,14 @@ resource "aws_lambda_function" "lambda" {
 
   environment {
     variables = {
-      SLACK_CHANNEL      = element(var.slack_channels, count.index)
-      SLACK_WEBHOOK_URL  = element(var.slack_webhook_urls, count.index)
-      SLACK_WEBHOOK_TYPE = var.slack_webhook_type
-      SLACK_EMOJI        = var.slack_emoji
-      SLACK_FIX_EMOJI    = var.slack_fix_emoji
-      SLACK_NEW_EMOJI    = var.slack_new_emoji
-      SLACK_USERNAME     = var.slack_username
-      PROJECT            = var.project
+      SLACK_CHANNEL                = element(var.slack_channels, count.index)
+      SLACK_WEBHOOK_URL_SECRET_ARN = element(var.slack_webhook_urls_secret_ids, count.index)
+      SLACK_WEBHOOK_TYPE           = var.slack_webhook_type
+      SLACK_EMOJI                  = var.slack_emoji
+      SLACK_FIX_EMOJI              = var.slack_fix_emoji
+      SLACK_NEW_EMOJI              = var.slack_new_emoji
+      SLACK_USERNAME               = var.slack_username
+      PROJECT                      = var.project
     }
   }
 

--- a/terraform-modules/lambda-slack/main.tf
+++ b/terraform-modules/lambda-slack/main.tf
@@ -43,14 +43,14 @@ resource "aws_lambda_function" "lambda" {
 
   environment {
     variables = {
-      SLACK_CHANNEL                = element(var.slack_channels, count.index)
-      SLACK_WEBHOOK_URL_SECRET_ARN = element(var.slack_webhook_urls_secret_ids, count.index)
-      SLACK_WEBHOOK_TYPE           = var.slack_webhook_type
-      SLACK_EMOJI                  = var.slack_emoji
-      SLACK_FIX_EMOJI              = var.slack_fix_emoji
-      SLACK_NEW_EMOJI              = var.slack_new_emoji
-      SLACK_USERNAME               = var.slack_username
-      PROJECT                      = var.project
+      SLACK_CHANNEL               = element(var.slack_channels, count.index)
+      SLACK_WEBHOOK_URL_SECRET_ID = element(var.slack_webhook_urls_secret_ids, count.index)
+      SLACK_WEBHOOK_TYPE          = var.slack_webhook_type
+      SLACK_EMOJI                 = var.slack_emoji
+      SLACK_FIX_EMOJI             = var.slack_fix_emoji
+      SLACK_NEW_EMOJI             = var.slack_new_emoji
+      SLACK_USERNAME              = var.slack_username
+      PROJECT                     = var.project
     }
   }
 

--- a/terraform-modules/lambda-slack/variables.tf
+++ b/terraform-modules/lambda-slack/variables.tf
@@ -6,7 +6,7 @@ variable "memory_size" {}
 variable "sns_topic_arn" {}
 variable "dlq_sns_topic_arn" {}
 variable "slack_channels" {}
-variable "slack_webhook_urls" {}
+variable "slack_webhook_urls_secret_ids" {}
 variable "slack_webhook_type" {}
 variable "slack_emoji" {}
 variable "slack_fix_emoji" {}

--- a/terraform-modules/secret-manager/main.tf
+++ b/terraform-modules/secret-manager/main.tf
@@ -1,0 +1,37 @@
+resource "random_string" "suffix" {
+  count     = length(var.secret_values)
+  length    = 8
+  min_lower = 8
+}
+
+resource "aws_secretsmanager_secret" "secret_name" {
+  count                   = length(var.secret_values)
+  name                    = "${var.project}-${var.secret_type}-${random_string.suffix[count.index].result}"
+  recovery_window_in_days = var.recovery_windows_in_days
+  kms_key_id              = var.kms_arn
+  description             = "${var.secret_type} value for ${var.project}"
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "secret_version_manual" {
+  count         = var.manual_secret_upload ? length(var.secret_values) : 0
+  secret_id     = element(aws_secretsmanager_secret.secret_name, count.index).id
+  secret_string = element(var.secret_values, count.index)
+  lifecycle {
+    ignore_changes = [
+      secret_id,
+      secret_string
+    ]
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "secret_version_auto" {
+  count         = var.manual_secret_upload ? 0 : length(var.secret_values)
+  secret_id     = element(aws_secretsmanager_secret.secret_name, count.index).id
+  secret_string = element(var.secret_values, count.index)
+  lifecycle {
+    ignore_changes = [
+      secret_id
+    ]
+  }
+}

--- a/terraform-modules/secret-manager/outputs.tf
+++ b/terraform-modules/secret-manager/outputs.tf
@@ -1,0 +1,9 @@
+output "secret_ids" {
+  description = "Secret ids list"
+  value       = [for k, v in aws_secretsmanager_secret.secret_name : v.id]
+}
+
+output "secret_arns" {
+  description = "Secrets arns list"
+  value       = [for v in aws_secretsmanager_secret.secret_name : v.arn]
+}

--- a/terraform-modules/secret-manager/variables.tf
+++ b/terraform-modules/secret-manager/variables.tf
@@ -1,0 +1,7 @@
+variable "project" {}
+variable "kms_arn" {}
+variable "secret_type" {}
+variable "secret_values" {}
+variable "recovery_windows_in_days" {}
+variable "manual_secret_upload" {}
+variable "tags" {}

--- a/unittests/utils/test_utils_aws.py
+++ b/unittests/utils/test_utils_aws.py
@@ -1,12 +1,15 @@
 from unittest.mock import patch
 
 from assertpy import assert_that
+from boto3 import client
 from boto3 import Session
+from moto import mock_secretsmanager
 
 from utils.utils_aws import assume_role
 from utils.utils_aws import create_session
 from utils.utils_aws import generate_role_arn
 from utils.utils_aws import generate_temporary_credentials
+from utils.utils_aws import get_secret_manager_value
 
 
 def get_test_credentials():
@@ -218,3 +221,12 @@ def test_assume_role_logs_message_on_exception(os_environ_mock, generate_temp_cr
     _ = assume_role("some_account")
 
     log_mock.assert_called_once_with("ERROR: Failed to assume test_role role in AWS account some_account")
+
+
+@mock_secretsmanager
+def test_get_secret_manager_value():
+    sm_client = client("secretsmanager", region_name="us-east-1")
+
+    sm_client.create_secret(Name="slack_token", SecretString="secret")
+    result = get_secret_manager_value("slack_token", client=sm_client)
+    assert result == "secret"

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -259,12 +259,13 @@ def domain_deleted(domain, account_name):
     return True
 
 
-def get_secret_value(secret_name):
+def get_secret_manager_value(secret_name, client=None):
 
-    client = boto3.client(
-        service_name="secretsmanager",
-        region_name=os.environ["AWS_REGION"],
-    )
+    if client is None:
+        client = boto3.client(
+            service_name="secretsmanager",
+            region_name=os.environ["AWS_REGION"],
+        )
 
     try:
         get_secret_value_response = client.get_secret_value(

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -257,3 +257,31 @@ def domain_deleted(domain, account_name):
     print(f"{domain} no longer in Route53 registered domains")
 
     return True
+
+
+def get_secret_value(secret_name):
+
+    client = boto3.client(
+        service_name="secretsmanager",
+        region_name=os.environ["AWS_REGION"],
+    )
+
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name,
+        )
+
+        if get_secret_value_response:
+            return get_secret_value_response["SecretString"]
+
+    except client.exceptions.ResourceNotFoundException as e:
+        logging.exception(
+            f"WARNING: Secret with name '{secret_name}' does not exist",
+        )
+        raise e
+    except exceptions.ClientError as e:
+        logging.exception(
+            "WARNING: Unable to retrieve value from %s",
+            secret_name,
+        )
+        raise e

--- a/variables.tf
+++ b/variables.tf
@@ -218,3 +218,8 @@ variable "allowed_regions" {
   description = "If SCPs block certain regions across all accounts, optionally replace with string formatted list of allowed regions"
   default     = "['all']" # example "['eu-west-1', 'us-east-1']"
 }
+
+variable "manual_secret_upload" {
+  description = "Set to false to get the secret value from environment variables (tfvars file). Set to true to manually put in secret values to Secret Manager"
+  default     = false
+}


### PR DESCRIPTION
This is my attempt to use secret manager for slack urls. The workflow is a bit different from what we discussed in the call.
- If the var `values_not_stored_in_secret_manager` is set to `true`, things will work as it is (using environment variable values to get secret values)
-  If the var `values_not_stored_in_secret_manager` is set to `true`, user will have to put in the secret values manually. This is due to https://github.com/hashicorp/terraform/issues/3116