### PR TITLE
add permissions_boundary_arn variable to set permissions boundary on all IAM roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "lambda-role" {
   region                   = var.region
   security_audit_role_name = var.security_audit_role_name
   kms_arn                  = module.kms.kms_arn
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "lambda-slack" {
@@ -72,6 +73,7 @@ module "accounts-role" {
   kms_arn                  = module.kms.kms_arn
   state_machine_arn        = module.step-function.state_machine_arn
   policy                   = "accounts"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "lambda-scan" {
@@ -118,6 +120,7 @@ module "takeover-role" {
   kms_arn                  = module.kms.kms_arn
   takeover                 = local.takeover
   policy                   = "takeover"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "lambda-resources" {
@@ -141,6 +144,7 @@ module "resources-role" {
   security_audit_role_name = var.security_audit_role_name
   kms_arn                  = module.kms.kms_arn
   policy                   = "resources"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "cloudwatch-event" {
@@ -248,6 +252,7 @@ module "step-function-role" {
   kms_arn                  = module.kms.kms_arn
   policy                   = "state"
   assume_role_policy       = "state"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "step-function" {
@@ -284,6 +289,7 @@ module "lambda-role-ips" {
   kms_arn                  = module.kms.kms_arn
   policy                   = "lambda"
   role_name                = "lambda-ips"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "lambda-scan-ips" {
@@ -321,6 +327,7 @@ module "accounts-role-ips" {
   state_machine_arn        = module.step-function-ips[0].state_machine_arn
   policy                   = "accounts"
   role_name                = "accounts-ips"
+  permissions_boundary_arn = var.permissions_boundary_arn
 }
 
 module "lambda-accounts-ips" {

--- a/terraform-modules/iam/main.tf
+++ b/terraform-modules/iam/main.tf
@@ -1,7 +1,8 @@
 resource "aws_iam_role" "lambda" {
-  name                = "${var.project}-${local.role_name}-${local.env}"
-  assume_role_policy  = templatefile("${path.module}/templates/${var.assume_role_policy}_role.json.tpl", { project = var.project })
-  managed_policy_arns = var.takeover ? ["arn:aws:iam::aws:policy/AmazonVPCFullAccess", "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"] : []
+  name                 = "${var.project}-${local.role_name}-${local.env}"
+  assume_role_policy   = templatefile("${path.module}/templates/${var.assume_role_policy}_role.json.tpl", { project = var.project })
+  managed_policy_arns  = var.takeover ? ["arn:aws:iam::aws:policy/AmazonVPCFullAccess", "arn:aws:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk", "arn:aws:iam::aws:policy/AmazonS3FullAccess", "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess"] : []
+  permissions_boundary = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy" "lambda" {

--- a/terraform-modules/iam/variables.tf
+++ b/terraform-modules/iam/variables.tf
@@ -27,3 +27,8 @@ variable "role_name" {
   description = "role name if different from policy name"
   default     = "policyname"
 }
+
+variable "permissions_boundary_arn" {
+  description = "permissions boundary ARN"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -218,3 +218,8 @@ variable "allowed_regions" {
   description = "If SCPs block certain regions across all accounts, optionally replace with string formatted list of allowed regions"
   default     = "['all']" # example "['eu-west-1', 'us-east-1']"
 }
+
+variable "permissions_boundary_arn" {
+  description = "permissions boundary ARN to attach to every IAM role"
+  default     = ""
+}


### PR DESCRIPTION
This adds a new variable `permissions_boundary_arn` that you can optionally set to set the `permissions_boundary` argument on all `aws_iam_role` resources created by `domain-protect`.

Fixes #237 