### PR TITLE
AWS manual scans: fix CloudFront scenarios

### DIFF
--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
+from moto import mock_cloudfront
 from moto import mock_route53
 
 from integration_tests.mocks.cloudflare_mock import CloudFlareMock
@@ -38,3 +39,10 @@ def aws_credentials():
 def moto_route53(aws_credentials):
     with mock_route53():
         yield boto3.client("route53", region_name="us-east-1")
+
+
+# pylint: disable=unused-argument
+@pytest.fixture(scope="function")
+def moto_cloudfront(aws_credentials):
+    with mock_cloudfront():
+        yield boto3.client("cloudfront", region_name="us-east-1")

--- a/integration_tests/manual_scans/aws/common.py
+++ b/integration_tests/manual_scans/aws/common.py
@@ -1,3 +1,62 @@
+def setup_cloudfront_distribution_with_origin_url(moto_cloudfront, origin_domain_name, is_s3=True):
+    # NOTE: All the fields below are required
+    config = {
+        "Origins": {
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "MyOrigin",
+                    "DomainName": origin_domain_name,
+                    "S3OriginConfig": {
+                        "OriginAccessIdentity": "",
+                    },
+                },
+            ],
+        },
+        "Enabled": True,
+        "Comment": "test",
+        "CallerReference": "test",
+        "Aliases": {
+            "Quantity": 2,
+            "Items": [
+                "vulnerable.domain-protect.com",
+                "something.else.com",
+            ],
+        },
+        "DefaultCacheBehavior": {
+            "AllowedMethods": {
+                "Quantity": 2,
+                "Items": ["GET", "HEAD"],
+                "CachedMethods": {
+                    "Quantity": 2,
+                    "Items": ["GET", "HEAD"],
+                },
+            },
+            "ViewerProtocolPolicy": "allow-all",
+            "TargetOriginId": "MyOrigin",
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {
+                    "Forward": "none",
+                },
+            },
+        },
+    }
+    if not is_s3:
+        del config["Origins"]["Items"][0]["S3OriginConfig"]
+        config["Origins"]["Items"][0]["CustomOriginConfig"] = {
+            "HTTPPort": 80,
+            "HTTPSPort": 443,
+            "OriginProtocolPolicy": "http-only",
+        }
+
+    distribution = moto_cloudfront.create_distribution(DistributionConfig=config)
+
+    # NOTE: From moto's documentation, this list_distributions() call is needed to "advance" the distribution to a deployed state
+    distributions = moto_cloudfront.list_distributions()
+    return distributions["DistributionList"]["Items"][0]
+
+
 def setup_hosted_zone_with_alias(moto_route53, target_dns_name):
     hosted_zone = moto_route53.create_hosted_zone(
         Name="domain-protect.com",
@@ -45,7 +104,7 @@ def setup_hosted_zone_with_cname(moto_route53, target_dns_name):
                         "ResourceRecords": [
                             {
                                 "Value": target_dns_name,
-                            }
+                            },
                         ],
                     },
                 },

--- a/integration_tests/manual_scans/aws/common.py
+++ b/integration_tests/manual_scans/aws/common.py
@@ -1,0 +1,26 @@
+def setup_hosted_zone(moto_route53, dns_name):
+    hosted_zone = moto_route53.create_hosted_zone(
+        Name="domain-protect.com",
+        CallerReference="123abc",
+        HostedZoneConfig={"Comment": "", "PrivateZone": False},
+    )
+    moto_route53.change_resource_record_sets(
+        HostedZoneId=hosted_zone["HostedZone"]["Id"],
+        ChangeBatch={
+            "Comment": "Create alias record set",
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "vulnerable.domain-protect.com",
+                        "Type": "A",
+                        "AliasTarget": {
+                            "HostedZoneId": hosted_zone["HostedZone"]["Id"],
+                            "DNSName": dns_name,
+                            "EvaluateTargetHealth": False,
+                        },
+                    },
+                },
+            ],
+        },
+    )

--- a/integration_tests/manual_scans/aws/common.py
+++ b/integration_tests/manual_scans/aws/common.py
@@ -1,4 +1,4 @@
-def setup_hosted_zone(moto_route53, dns_name):
+def setup_hosted_zone_with_alias(moto_route53, target_dns_name):
     hosted_zone = moto_route53.create_hosted_zone(
         Name="domain-protect.com",
         CallerReference="123abc",
@@ -16,9 +16,37 @@ def setup_hosted_zone(moto_route53, dns_name):
                         "Type": "A",
                         "AliasTarget": {
                             "HostedZoneId": hosted_zone["HostedZone"]["Id"],
-                            "DNSName": dns_name,
+                            "DNSName": target_dns_name,
                             "EvaluateTargetHealth": False,
                         },
+                    },
+                },
+            ],
+        },
+    )
+
+
+def setup_hosted_zone_with_cname(moto_route53, target_dns_name):
+    hosted_zone = moto_route53.create_hosted_zone(
+        Name="domain-protect.com",
+        CallerReference="123abc",
+        HostedZoneConfig={"Comment": "", "PrivateZone": False},
+    )
+    moto_route53.change_resource_record_sets(
+        HostedZoneId=hosted_zone["HostedZone"]["Id"],
+        ChangeBatch={
+            "Comment": "Create CNAME record set",
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": "vulnerable.domain-protect.com",
+                        "Type": "CNAME",
+                        "ResourceRecords": [
+                            {
+                                "Value": target_dns_name,
+                            }
+                        ],
                     },
                 },
             ],

--- a/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
@@ -2,7 +2,7 @@ from unittest.mock import call
 from unittest.mock import patch
 
 import requests
-from common import setup_hosted_zone
+from common import setup_hosted_zone_with_alias
 
 from manual_scans.aws.aws_alias_cloudfront_s3 import main
 
@@ -10,7 +10,7 @@ from manual_scans.aws.aws_alias_cloudfront_s3 import main
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
 
@@ -27,7 +27,7 @@ def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_r
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=200, text="All good here")
 
@@ -39,7 +39,7 @@ def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, mo
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_ignores_domains_with_connection_error(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
 
     requests_mock.get("https://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
 

--- a/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
@@ -1,0 +1,48 @@
+from unittest.mock import call
+from unittest.mock import patch
+
+import requests
+from common import setup_hosted_zone
+
+from manual_scans.aws.aws_alias_cloudfront_s3 import main
+
+
+@patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
+
+    main()
+
+    print_list_mock.assert_has_calls(
+        [
+            call(["vulnerable.domain-protect.com."], "INSECURE_WS"),
+            call(["abcd.cloudfront.net"], "OUTPUT_WS"),
+        ],
+    )
+
+
+@patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=200, text="All good here")
+
+    main()
+
+    print_list_mock.assert_not_called()
+
+
+@patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_ignores_domains_with_connection_error(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
+
+    main()
+
+    print_list_mock.assert_not_called()

--- a/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_cloudfront.py
@@ -2,6 +2,7 @@ from unittest.mock import call
 from unittest.mock import patch
 
 import requests
+from common import setup_cloudfront_distribution_with_origin_url
 from common import setup_hosted_zone_with_alias
 
 from manual_scans.aws.aws_alias_cloudfront_s3 import main
@@ -9,25 +10,34 @@ from manual_scans.aws.aws_alias_cloudfront_s3 import main
 
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
+def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, moto_cloudfront, requests_mock):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, cloudfront["DomainName"])
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
+    requests_mock.get("https://my-bucket.s3.us-east-1.amazonaws.com", status_code=404, text="<Code>NoSuchBucket</Code>")
 
     main()
 
     print_list_mock.assert_has_calls(
         [
             call(["vulnerable.domain-protect.com."], "INSECURE_WS"),
-            call(["abcd.cloudfront.net"], "OUTPUT_WS"),
+            call([cloudfront["DomainName"]], "OUTPUT_WS"),
         ],
     )
 
 
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
+def test_main_ignores_non_vulnerable_domains(
+    arg_parse_mock,
+    print_list_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, cloudfront["DomainName"])
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=200, text="All good here")
 
@@ -38,11 +48,50 @@ def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, mo
 
 @patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-def test_main_ignores_domains_with_connection_error(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_alias(moto_route53, "abcd.cloudfront.net")
+def test_main_ignores_non_vulnerable_domains_2(
+    arg_parse_mock,
+    print_list_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, cloudfront["DomainName"])
 
-    requests_mock.get("https://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
+    requests_mock.get("https://my-bucket.s3.us-east-1.amazonaws.com", status_code=200, text="All good there")
+    main()
+
+    print_list_mock.assert_not_called()
+
+
+@patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_ignores_domains_with_non_s3_origins(
+    arg_parse_mock,
+    print_list_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(
+        moto_cloudfront,
+        "non-s3-origin.example.com",
+        is_s3=False,
+    )
+    setup_hosted_zone_with_alias(moto_route53, cloudfront["DomainName"])
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
 
     main()
 
     print_list_mock.assert_not_called()
+
+
+@patch("manual_scans.aws.aws_alias_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_no_cloudfront_distribution(arg_parse_mock, print_list_mock, moto_route53, moto_cloudfront, requests_mock):
+    main()
+
+    print_list_mock.assert_not_called()
+    # Implicitly, we also assert no exception is raised

--- a/integration_tests/manual_scans/aws/test_aws_alias_s3.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_s3.py
@@ -9,7 +9,8 @@ from manual_scans.aws.aws_alias_s3 import main
 
 @patch("manual_scans.aws.aws_alias_s3.print_list")
 @patch("argparse.ArgumentParser")
-def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, moto_cloudfront, requests_mock):
+
     setup_hosted_zone_with_alias(moto_route53, "dns_mock.s3-website.amazonaws.com")
 
     requests_mock.get("http://vulnerable.domain-protect.com.", status_code=404, text="Code: NoSuchBucket")

--- a/integration_tests/manual_scans/aws/test_aws_alias_s3.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_s3.py
@@ -2,7 +2,7 @@ from unittest.mock import call
 from unittest.mock import patch
 
 import requests
-from common import setup_hosted_zone
+from common import setup_hosted_zone_with_alias
 
 from manual_scans.aws.aws_alias_s3 import main
 
@@ -10,7 +10,7 @@ from manual_scans.aws.aws_alias_s3 import main
 @patch("manual_scans.aws.aws_alias_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "dns_mock.s3-website.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, "dns_mock.s3-website.amazonaws.com")
 
     requests_mock.get("http://vulnerable.domain-protect.com.", status_code=404, text="Code: NoSuchBucket")
 
@@ -24,7 +24,7 @@ def test_main_detects_vulnerable_domains(arg_parse_mock, print_list_mock, moto_r
 @patch("manual_scans.aws.aws_alias_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "dns_mock.s3-website.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, "dns_mock.s3-website.amazonaws.com")
 
     requests_mock.get("http://vulnerable.domain-protect.com.", status_code=200, text="All good here")
 
@@ -36,7 +36,7 @@ def test_main_ignores_non_vulnerable_domains(arg_parse_mock, print_list_mock, mo
 @patch("manual_scans.aws.aws_alias_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_ignores_non_s3_domains(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "dns_mock.blah.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, "dns_mock.blah.amazonaws.com")
 
     requests_mock.get("http://vulnerable.domain-protect.com.", status_code=404, text="Code: NoSuchBucket")
 
@@ -48,7 +48,7 @@ def test_main_ignores_non_s3_domains(arg_parse_mock, print_list_mock, moto_route
 @patch("manual_scans.aws.aws_alias_s3.print_list")
 @patch("argparse.ArgumentParser")
 def test_main_ignores_domains_with_connection_error(arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone(moto_route53, "dns_mock.s3-website.amazonaws.com")
+    setup_hosted_zone_with_alias(moto_route53, "dns_mock.s3-website.amazonaws.com")
 
     requests_mock.get("http://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
 

--- a/integration_tests/manual_scans/aws/test_aws_alias_s3.py
+++ b/integration_tests/manual_scans/aws/test_aws_alias_s3.py
@@ -2,36 +2,9 @@ from unittest.mock import call
 from unittest.mock import patch
 
 import requests
+from common import setup_hosted_zone
 
 from manual_scans.aws.aws_alias_s3 import main
-
-
-def setup_hosted_zone(moto_route53, dns_name):
-    hosted_zone = moto_route53.create_hosted_zone(
-        Name="domain-protect.com",
-        CallerReference="123abc",
-        HostedZoneConfig={"Comment": "", "PrivateZone": False},
-    )
-    moto_route53.change_resource_record_sets(
-        HostedZoneId=hosted_zone["HostedZone"]["Id"],
-        ChangeBatch={
-            "Comment": "Create alias record set",
-            "Changes": [
-                {
-                    "Action": "CREATE",
-                    "ResourceRecordSet": {
-                        "Name": "vulnerable.domain-protect.com",
-                        "Type": "A",
-                        "AliasTarget": {
-                            "HostedZoneId": hosted_zone["HostedZone"]["Id"],
-                            "DNSName": dns_name,
-                            "EvaluateTargetHealth": False,
-                        },
-                    },
-                },
-            ],
-        },
-    )
 
 
 @patch("manual_scans.aws.aws_alias_s3.print_list")

--- a/integration_tests/manual_scans/aws/test_aws_cname_cloudfront.py
+++ b/integration_tests/manual_scans/aws/test_aws_cname_cloudfront.py
@@ -1,8 +1,10 @@
 from unittest.mock import call
-from unittest.mock import patch
 from unittest.mock import Mock
+from unittest.mock import patch
 
+import pytest
 import requests
+from common import setup_cloudfront_distribution_with_origin_url
 from common import setup_hosted_zone_with_cname
 
 from manual_scans.aws.aws_cname_cloudfront_s3 import main
@@ -10,26 +12,42 @@ from manual_scans.aws.aws_cname_cloudfront_s3 import main
 
 @patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
-def test_main_detects_vulnerable_domains(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+def test_main_detects_vulnerable_domains(
+    arg_parse_mock,
+    print_list_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+    dns_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_cname(moto_route53, cloudfront["DomainName"])
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
-    
+    requests_mock.get("https://my-bucket.s3.us-east-1.amazonaws.com", status_code=404, text="<Code>NoSuchBucket</Code>")
+    dns_mock.add_lookup("vulnerable.domain-protect.com.", cloudfront["DomainName"], record_type="CNAME")
+
     main()
 
     print_list_mock.assert_has_calls(
         [
-            call(["vulnerable.domain-protect.com."], "INSECURE_WS")
+            call(["vulnerable.domain-protect.com."], "INSECURE_WS"),
         ],
     )
 
 
 @patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
-def test_main_ignores_non_vulnerable_domains(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+def test_main_ignores_non_vulnerable_domains(
+    arg_parse_mock,
+    print_list_mock,
+    dns_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_cname(moto_route53, cloudfront["DomainName"])
 
     requests_mock.get("https://vulnerable.domain-protect.com.", status_code=200, text="All good here")
 
@@ -38,14 +56,61 @@ def test_main_ignores_non_vulnerable_domains(dns_mock, arg_parse_mock, print_lis
     print_list_mock.assert_not_called()
 
 
+@patch("utils.utils_dns.firewall_test")
 @patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
 @patch("argparse.ArgumentParser")
-@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
-def test_main_ignores_domains_with_connection_error(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
-    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+def test_main_ignores_non_vulnerable_domains_2(
+    arg_parse_mock,
+    print_list_mock,
+    dns_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_cname(moto_route53, cloudfront["DomainName"])
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
+    requests_mock.get("https://my-bucket.s3.us-east-1.amazonaws.com", status_code=200, text="All good there")
+
+    main()
+
+    print_list_mock.assert_not_called()
+
+
+@patch("utils.utils_dns.firewall_test")
+@patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_ignores_domains_with_connection_error(
+    arg_parse_mock,
+    print_list_mock,
+    dns_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    cloudfront = setup_cloudfront_distribution_with_origin_url(moto_cloudfront, "my-bucket.s3.us-east-1.amazonaws.com")
+    setup_hosted_zone_with_cname(moto_route53, cloudfront["DomainName"])
 
     requests_mock.get("https://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
 
     main()
 
     print_list_mock.assert_not_called()
+
+
+@patch("utils.utils_dns.firewall_test")
+@patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+def test_main_no_cloudfront_distribution(
+    arg_parse_mock,
+    print_list_mock,
+    dns_mock,
+    moto_route53,
+    moto_cloudfront,
+    requests_mock,
+):
+    main()
+
+    print_list_mock.assert_not_called()
+    # Implicitly, we also assert no exception is raised

--- a/integration_tests/manual_scans/aws/test_aws_cname_cloudfront.py
+++ b/integration_tests/manual_scans/aws/test_aws_cname_cloudfront.py
@@ -1,0 +1,51 @@
+from unittest.mock import call
+from unittest.mock import patch
+from unittest.mock import Mock
+
+import requests
+from common import setup_hosted_zone_with_cname
+
+from manual_scans.aws.aws_cname_cloudfront_s3 import main
+
+
+@patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
+def test_main_detects_vulnerable_domains(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=404, text="<Code>NotFound</Code>")
+    
+    main()
+
+    print_list_mock.assert_has_calls(
+        [
+            call(["vulnerable.domain-protect.com."], "INSECURE_WS")
+        ],
+    )
+
+
+@patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
+def test_main_ignores_non_vulnerable_domains(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", status_code=200, text="All good here")
+
+    main()
+
+    print_list_mock.assert_not_called()
+
+
+@patch("manual_scans.aws.aws_cname_cloudfront_s3.print_list")
+@patch("argparse.ArgumentParser")
+@patch("dns.resolver.resolve", return_value=[Mock(target="abcd.cloudfront.net")])
+def test_main_ignores_domains_with_connection_error(dns_mock, arg_parse_mock, print_list_mock, moto_route53, requests_mock):
+    setup_hosted_zone_with_cname(moto_route53, "abcd.cloudfront.net")
+
+    requests_mock.get("https://vulnerable.domain-protect.com.", exc=requests.exceptions.ConnectionError)
+
+    main()
+
+    print_list_mock.assert_not_called()

--- a/integration_tests/mocks/dns_mock.py
+++ b/integration_tests/mocks/dns_mock.py
@@ -5,6 +5,7 @@ class DNSLookup:
     def __init__(self, name, content, exception=None, record_type="A") -> None:
         self.name = name
         self.content = content
+        self.target = content
         self.exception = exception
         self.record_type = record_type
 

--- a/manual_scans/aws/README.md
+++ b/manual_scans/aws/README.md
@@ -35,7 +35,7 @@ $ export PYTHONPATH="${PYTHONPATH}:/Users/paul/src/github.com/domain-protect/dom
 
 
 ```
-python manual_scans/aws/aws_alias_cloudfront-s3.py
+python manual_scans/aws/aws_alias_cloudfront_s3.py
 ```
 
 ![Alt text](images/aws-cloudfront-s3-alias.png?raw=true "CloudFront Alias with missing S3 origin")

--- a/manual_scans/aws/README.md
+++ b/manual_scans/aws/README.md
@@ -35,7 +35,7 @@ $ export PYTHONPATH="${PYTHONPATH}:/Users/paul/src/github.com/domain-protect/dom
 
 
 ```
-python manual_scans/aws/aws-alias-cloudfront-s3.py
+python manual_scans/aws/aws_alias_cloudfront-s3.py
 ```
 
 ![Alt text](images/aws-cloudfront-s3-alias.png?raw=true "CloudFront Alias with missing S3 origin")

--- a/manual_scans/aws/README.md
+++ b/manual_scans/aws/README.md
@@ -43,7 +43,7 @@ python manual_scans/aws/aws_alias_cloudfront-s3.py
 ## CloudFront CNAME with missing S3 origin
 
 ```
-python manual_scans/aws/aws-cname-cloudfront-s3.py
+python manual_scans/aws/aws_cname_cloudfront_s3.py
 ```
 
 ![Alt text](images/aws-cloudfront-s3-cname.png?raw=true "CloudFront CNAME with missing S3 origin")

--- a/manual_scans/aws/aws_alias_cloudfront_s3.py
+++ b/manual_scans/aws/aws_alias_cloudfront_s3.py
@@ -7,6 +7,7 @@ import requests
 from utils.utils_aws_manual import bucket_does_not_exist
 from utils.utils_aws_manual import get_cloudfront_origin_url
 from utils.utils_aws_manual import is_s3_bucket_url
+from utils.utils_aws_manual import is_s3_website_endpoint_url
 from utils.utils_aws_manual import list_hosted_zones_manual_scan
 from utils.utils_print import my_print
 from utils.utils_print import print_list
@@ -18,7 +19,7 @@ def vulnerable_alias_cloudfront_s3(domain_name):
 
         if response.status_code == 404 and "<Code>NotFound</Code>" in response.text:
             bucket_url = get_cloudfront_origin_url(domain_name)
-            if not is_s3_bucket_url(bucket_url):
+            if not is_s3_bucket_url(bucket_url) and not is_s3_website_endpoint_url(bucket_url):
                 return False
 
             return bucket_does_not_exist(bucket_url)

--- a/manual_scans/aws/aws_alias_cloudfront_s3.py
+++ b/manual_scans/aws/aws_alias_cloudfront_s3.py
@@ -4,18 +4,24 @@ import argparse
 import boto3
 import requests
 
+from utils.utils_aws_manual import bucket_does_not_exist
+from utils.utils_aws_manual import get_cloudfront_origin_url
+from utils.utils_aws_manual import is_s3_bucket_url
 from utils.utils_aws_manual import list_hosted_zones_manual_scan
 from utils.utils_print import my_print
 from utils.utils_print import print_list
 
 
 def vulnerable_alias_cloudfront_s3(domain_name):
-
     try:
         response = requests.get(f"https://{domain_name}", timeout=1)
 
         if response.status_code == 404 and "<Code>NotFound</Code>" in response.text:
-            return True
+            bucket_url = get_cloudfront_origin_url(domain_name)
+            if not is_s3_bucket_url(bucket_url):
+                return False
+
+            return bucket_does_not_exist(bucket_url)
 
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
         pass

--- a/manual_scans/aws/aws_alias_cloudfront_s3.py
+++ b/manual_scans/aws/aws_alias_cloudfront_s3.py
@@ -9,16 +9,12 @@ from utils.utils_print import my_print
 from utils.utils_print import print_list
 
 
-vulnerable_domains = []
-missing_resources = []
-
-
 def vulnerable_alias_cloudfront_s3(domain_name):
 
     try:
         response = requests.get(f"https://{domain_name}", timeout=1)
 
-        if response.status_code == 404 and "Code: NoSuchBucket" in response.text:
+        if response.status_code == 404 and "<Code>NotFound</Code>" in response.text:
             return True
 
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
@@ -28,6 +24,8 @@ def vulnerable_alias_cloudfront_s3(domain_name):
 
 
 def route53():
+    vulnerable_domains = []
+    missing_resources = []
 
     print("Searching for Route53 hosted zones")
 
@@ -60,12 +58,13 @@ def route53():
                 else:
                     my_print(f"{str(i)}. {record['Name']}", "SECURE")
 
+    return vulnerable_domains, missing_resources
 
-if __name__ == "__main__":
 
+def main():
     parser = argparse.ArgumentParser(description="Prevent Subdomain Takeover")
 
-    route53()
+    vulnerable_domains, missing_resources = route53()
 
     count = len(vulnerable_domains)
     my_print(f"\nTotal Vulnerable Domains Found: {str(count)}", "INFOB")
@@ -76,3 +75,7 @@ if __name__ == "__main__":
 
         my_print("\nCloudFront distributions with missing S3 origin: ", "INFOB")
         print_list(missing_resources, "OUTPUT_WS")
+
+
+if __name__ == "__main__":
+    main()

--- a/manual_scans/aws/aws_cname_cloudfront_s3.py
+++ b/manual_scans/aws/aws_cname_cloudfront_s3.py
@@ -8,6 +8,7 @@ import requests
 from utils.utils_aws_manual import bucket_does_not_exist
 from utils.utils_aws_manual import get_cloudfront_origin_url
 from utils.utils_aws_manual import is_s3_bucket_url
+from utils.utils_aws_manual import is_s3_website_endpoint_url
 from utils.utils_aws_manual import list_hosted_zones_manual_scan
 from utils.utils_dns import firewall_test
 from utils.utils_print import my_print
@@ -20,7 +21,7 @@ def vulnerable_cname_cloudfront_s3(domain_name):
 
         if response.status_code == 404 and "<Code>NotFound</Code>" in response.text:
             bucket_url = get_cloudfront_origin_url(domain_name)
-            if not is_s3_bucket_url(bucket_url):
+            if not is_s3_bucket_url(bucket_url) and not is_s3_website_endpoint_url(bucket_url):
                 return False
 
             return bucket_does_not_exist(bucket_url)

--- a/manual_scans/aws/aws_cname_cloudfront_s3.py
+++ b/manual_scans/aws/aws_cname_cloudfront_s3.py
@@ -10,15 +10,13 @@ from utils.utils_dns import firewall_test
 from utils.utils_print import my_print
 from utils.utils_print import print_list
 
-vulnerable_domains = []
-
 
 def vulnerable_cname_cloudfront_s3(domain_name):
 
     try:
         response = requests.get(f"https://{domain_name}", timeout=1)
 
-        if response.status_code == 404 and "Code: NoSuchBucket" in response.text:
+        if response.status_code == 404 and "<Code>NotFound</Code>" in response.text:
             return True
 
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
@@ -28,6 +26,7 @@ def vulnerable_cname_cloudfront_s3(domain_name):
 
 
 def route53():
+    vulnerable_domains = []
 
     print("Searching for Route53 hosted zones")
 
@@ -66,20 +65,20 @@ def route53():
                 else:
                     my_print(f"{str(i)}. {record['Name']}", "SECURE")
 
+    return vulnerable_domains
 
-if __name__ == "__main__":
-
+def main():
     parser = argparse.ArgumentParser(description="Prevent Subdomain Takeover")
 
     firewall_test()
-    route53()
+    vulnerable_domains = route53()
 
     count = len(vulnerable_domains)
     my_print("\nTotal Vulnerable Domains Found: " + str(count), "INFOB")
 
     if count > 0:
         my_print("List of Vulnerable Domains:", "INFOB")
-        print_list(vulnerable_domains)
+        print_list(vulnerable_domains, "INSECURE_WS")
 
         print("")
         my_print("CloudFront distributions with missing S3 origin:", "INFOB")
@@ -91,3 +90,6 @@ if __name__ == "__main__":
                 cname = cname_value.target
                 cname_string = str(cname)
                 my_print(f"{str(i)}. {cname_string}", "OUTPUT_WS")
+    
+if __name__ == "__main__":
+    main()

--- a/unittests/utils/test_utils_aws_manual.py
+++ b/unittests/utils/test_utils_aws_manual.py
@@ -1,17 +1,36 @@
 import unittest
 
 from utils.utils_aws_manual import is_s3_bucket_url
+from utils.utils_aws_manual import is_s3_website_endpoint_url
 
-class TestIsS3BucketURL(unittest.TestCase):
-  def test_not_bucket_url(self):
-    self.assertFalse(is_s3_bucket_url("example.com"))
-    
-  def test_direct_bucket_url(self):
-    self.assertTrue(is_s3_bucket_url("bucket.s3.amazonaws.com"))
-    
-  def test_direct_regional_bucket_url(self):
-    self.assertTrue(is_s3_bucket_url("bucket.s3.us-east-1.amazonaws.com"))
-    
-  def test_none_empty(self):
-    self.assertFalse(is_s3_bucket_url(None))
-    self.assertFalse(is_s3_bucket_url(""))
+
+class TestS3BucketURLs(unittest.TestCase):
+    def test_not_bucket_url(self):
+        self.assertFalse(is_s3_bucket_url("example.com"))
+
+    def test_direct_bucket_url(self):
+        self.assertTrue(is_s3_bucket_url("bucket.s3.amazonaws.com"))
+
+    def test_direct_regional_bucket_url(self):
+        self.assertTrue(is_s3_bucket_url("bucket.s3.us-east-1.amazonaws.com"))
+
+    def test_none_empty(self):
+        self.assertFalse(is_s3_bucket_url(None))
+        self.assertFalse(is_s3_bucket_url(""))
+
+
+class TestS3WebsiteURLs(unittest.TestCase):
+    def test_not_bucket_url(self):
+        self.assertFalse(is_s3_website_endpoint_url("example.com"))
+
+    # per https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html
+    # can have a dot or a dash separating the region
+    def test_website_url_dash(self):
+        self.assertTrue(is_s3_website_endpoint_url("bucket.s3-website-us-east-1.amazonaws.com"))
+
+    def test_website_url_dot(self):
+        self.assertTrue(is_s3_website_endpoint_url("bucket.s3-website.us-east-1.amazonaws.com"))
+
+    def test_none_empty(self):
+        self.assertFalse(is_s3_website_endpoint_url(None))
+        self.assertFalse(is_s3_website_endpoint_url(""))

--- a/unittests/utils/test_utils_aws_manual.py
+++ b/unittests/utils/test_utils_aws_manual.py
@@ -1,0 +1,17 @@
+import unittest
+
+from utils.utils_aws_manual import is_s3_bucket_url
+
+class TestIsS3BucketURL(unittest.TestCase):
+  def test_not_bucket_url(self):
+    self.assertFalse(is_s3_bucket_url("example.com"))
+    
+  def test_direct_bucket_url(self):
+    self.assertTrue(is_s3_bucket_url("bucket.s3.amazonaws.com"))
+    
+  def test_direct_regional_bucket_url(self):
+    self.assertTrue(is_s3_bucket_url("bucket.s3.us-east-1.amazonaws.com"))
+    
+  def test_none_empty(self):
+    self.assertFalse(is_s3_bucket_url(None))
+    self.assertFalse(is_s3_bucket_url(""))

--- a/utils/utils_aws_manual.py
+++ b/utils/utils_aws_manual.py
@@ -25,7 +25,6 @@ def list_hosted_zones_manual_scan():
 # Given the bucket's direct URL or S3 website URL, returns True if the bucket does not exist
 def bucket_does_not_exist(bucket_url):
     try:
-        # NOTE: We don't verify TLS, because the certificate matches the CloudFront's distribution domain name, not the S3 bucket's domain name
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", urllib3.exceptions.InsecureRequestWarning)
             response = requests.get("https://" + bucket_url, timeout=1, verify=False)  # nosec B501

--- a/utils/utils_aws_manual.py
+++ b/utils/utils_aws_manual.py
@@ -57,3 +57,8 @@ def get_cloudfront_origin_url(domain_name):
 def is_s3_bucket_url(url):
     # bucket.s3.amazonaws.com or bucket.s3.region.amazonaws.com
     return url is not None and regex.match(r"^.+\.s3.([a-z0-9-]+\.)?amazonaws.com$", url) is not None
+
+
+def is_s3_website_endpoint_url(url):
+    # bucket.s3-website-region.amazonaws.com
+    return url is not None and regex.match(r"^.+\.s3-website[-\.]([a-z0-9-]+\.)?amazonaws.com$", url) is not None

--- a/utils/utils_aws_manual.py
+++ b/utils/utils_aws_manual.py
@@ -1,4 +1,9 @@
+import warnings
+
 import boto3
+import regex
+import requests
+import urllib3
 
 
 def list_hosted_zones_manual_scan():
@@ -15,3 +20,40 @@ def list_hosted_zones_manual_scan():
         hosted_zones_list = hosted_zones_list + hosted_zones
 
     return hosted_zones_list
+
+
+def bucket_does_not_exist(bucket_url):
+    try:
+        # NOTE: We don't verify TLS, because the certificate matches the CloudFront's distribution domain name, not the S3 bucket's domain name
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", urllib3.exceptions.InsecureRequestWarning)
+            response = requests.get("https://" + bucket_url, timeout=1, verify=False)  # nosec B501
+
+        if response.status_code == 404 and "<Code>NoSuchBucket</Code>" in response.text:
+            return True
+
+    except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
+        pass
+
+    return False
+
+
+# Extracts the origin URL from a CloudFront distribution
+def get_cloudfront_origin_url(domain_name):
+    boto3_session = boto3.Session()
+    cloudfront = boto3_session.client("cloudfront")
+
+    # List CloudFront distributions, find the one with the matching domain name
+    paginator = cloudfront.get_paginator("list_distributions")
+    pages = paginator.paginate()
+    for page in pages:
+        for distribution in page["DistributionList"]["Items"]:
+            for alias in distribution["Aliases"]["Items"]:
+                if alias + "." == domain_name:
+                    # We found the right distribution
+                    return distribution["Origins"]["Items"][0]["DomainName"]
+
+
+def is_s3_bucket_url(url):
+    # bucket.s3.amazonaws.com or bucket.s3.region.amazonaws.com
+    return url is not None and regex.match(r"^.+\.s3.([a-z0-9-]+\.)?amazonaws.com$", url) is not None

--- a/utils/utils_aws_manual.py
+++ b/utils/utils_aws_manual.py
@@ -22,6 +22,7 @@ def list_hosted_zones_manual_scan():
     return hosted_zones_list
 
 
+# Given the bucket's direct URL or S3 website URL, returns True if the bucket does not exist
 def bucket_does_not_exist(bucket_url):
     try:
         # NOTE: We don't verify TLS, because the certificate matches the CloudFront's distribution domain name, not the S3 bucket's domain name
@@ -29,7 +30,12 @@ def bucket_does_not_exist(bucket_url):
             warnings.simplefilter("ignore", urllib3.exceptions.InsecureRequestWarning)
             response = requests.get("https://" + bucket_url, timeout=1, verify=False)  # nosec B501
 
+        # When accessed directly e.g. bucket.s3.amazonaws.com
         if response.status_code == 404 and "<Code>NoSuchBucket</Code>" in response.text:
+            return True
+
+        # When accessed through S3 website url e.g. bucket.s3-website-us-east-1.amazonaws.com
+        if response.status_code == 404 and "Code: NoSuchBucket" in response.text:
             return True
 
     except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):


### PR DESCRIPTION
As discussed (and tested) with Paul on Slack, the behavior of AWS has changed for these 2 use-cases.

A few notes:
* The logic was updated to not only look at the CloudFront URL response, but also ensure that the bucket does not exist
* Added integration tests for the 2 scripts that I touched

closes #244 