### PR TITLE
skips an alias in distributions if there is no Items key in it

### DIFF
--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -217,6 +217,8 @@ def get_cloudfront_s3_origin_url(account_id, account_name, domain):
             pages = paginator.paginate()
             for page in pages:
                 for distribution in page["DistributionList"]["Items"]:
+                    if "Items" not in distribution["Aliases"]:
+                        continue
                     for alias in distribution["Aliases"]["Items"]:
                         if alias + "." == domain:
                             # We found the right distribution

--- a/utils/utils_aws_manual.py
+++ b/utils/utils_aws_manual.py
@@ -53,6 +53,8 @@ def get_cloudfront_origin_url(domain_name):
     pages = paginator.paginate()
     for page in pages:
         for distribution in page["DistributionList"]["Items"]:
+            if "Items" not in distribution["Aliases"]:
+                continue
             for alias in distribution["Aliases"]["Items"]:
                 if alias + "." == domain_name:
                     # We found the right distribution


### PR DESCRIPTION
We had domain-protect raise a KeyError exception while scanning our cloudfront distributions-- it was trying to read the Items key from Aliases, but it didn't exist.

```
domain-protect % aws --profile=prd cloudfront list-distributions | jq '.DistributionList.Items[].Aliases | select(.Items==null)'
{
  "Quantity": 0
}
{
  "Quantity": 0
}
domain-protect %
```

This commit checks if the Items key does not exist, and continues to the next distribution if so.