### PR TITLE
Add environment override

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         args:
           - --zero-exit
         exclude: .\.tf | ^\.github/
+        additional_dependencies: ["setuptools"]
 -   repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.0
     hooks:

--- a/docs/bugcrowd.md
+++ b/docs/bugcrowd.md
@@ -21,7 +21,7 @@
 * by default this will be the `prd` Terraform workspace
 * if you have chosen a different Terraform workspace name for production, update Terraform variable:
 ```
-production_workspace = "prd"
+production_environment = "prd"
 ```
 * Bugcrowd issues are only created for vulnerability types which don't support automated takeover
 

--- a/docs/hackerone.md
+++ b/docs/hackerone.md
@@ -20,7 +20,7 @@ to help organisations improve their security and stay ahead of threats
 * by default this will be the `prd` Terraform workspace
 * if you have chosen a different Terraform workspace name for production, update Terraform variable:
 ```
-production_workspace = "prd"
+production_environment = "prd"
 ```
 * HackerOne issues are only created for vulnerability types which don't support automated takeover
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,7 +95,7 @@ terraform plan
 terraform apply
 ```
 
-### Overriding workspace name
+### Overriding workspace/environment name
 
 If you're using external tooling or systems where `terraform.workspace` works differently, you can override the value by setting the `environment` variable.
 
@@ -104,7 +104,7 @@ If you're using external tooling or systems where `terraform.workspace` works di
 environment="prod" # used instead of terraform.workspace
 ```
 
-Make sure to also update `production_workspace` to match the `environment` variable when deploying to production.
+Make sure to also update `production_environment` to match the `environment` variable when deploying to production.
 
 ## Adding notifications to extra Slack channels
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -97,14 +97,14 @@ terraform apply
 
 ### Overriding workspace name
 
-If you're using external tooling or systems where `terraform.workspace` works differently, you can override the value by setting `environment`.
+If you're using external tooling or systems where `terraform.workspace` works differently, you can override the value by setting the `environment` variable.
 
 ```hcl
 # terraform.tfvars
 environment="prod" # used instead of terraform.workspace
 ```
 
-Make sure to also update `production_workspace` to match the value you set in `environment` when deploying to production.
+Make sure to also update `production_workspace` to match the `environment` variable when deploying to production.
 
 ## Adding notifications to extra Slack channels
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -95,6 +95,17 @@ terraform plan
 terraform apply
 ```
 
+### Overriding workspace name
+
+If you're using external tooling or systems where `terraform.workspace` works differently, you can override the value by setting `environment`.
+
+```hcl
+# terraform.tfvars
+environment="prod" # used instead of terraform.workspace
+```
+
+Make sure to also update `production_workspace` to match the value you set in `environment` when deploying to production.
+
 ## Adding notifications to extra Slack channels
 
 * add an extra channel to your slack_channels variable list

--- a/lambda_code/cloudflare_scan/cloudflare_scan.py
+++ b/lambda_code/cloudflare_scan/cloudflare_scan.py
@@ -19,7 +19,7 @@ from utils.utils_sanitise import filtered_ns_records
 bugcrowd = os.environ["BUGCROWD"]
 hackerone = os.environ["HACKERONE"]
 env_name = os.environ["ENVIRONMENT"]
-production_env = os.environ["PRODUCTION_WORKSPACE"]
+production_env = os.environ["PRODUCTION_ENVIRONMENT"]
 
 
 def process_vulnerability(domain, account_name, resource_type, vulnerability_type, takeover=""):

--- a/lambda_code/scan/scan.py
+++ b/lambda_code/scan/scan.py
@@ -24,7 +24,7 @@ from utils.utils_sanitise import sanitise_wildcards
 bugcrowd = os.environ["BUGCROWD"]
 hackerone = os.environ["HACKERONE"]
 env_name = os.environ["ENVIRONMENT"]
-production_env = os.environ["PRODUCTION_WORKSPACE"]
+production_env = os.environ["PRODUCTION_ENVIRONMENT"]
 
 
 def process_vulnerability(domain, account_name, resource_type, vulnerability_type, takeover=""):

--- a/lambda_code/scan_ips/scan_ips.py
+++ b/lambda_code/scan_ips/scan_ips.py
@@ -25,7 +25,7 @@ from utils.utils_sanitise import sanitise_wildcards
 bugcrowd = os.environ["BUGCROWD"]
 hackerone = os.environ["HACKERONE"]
 env_name = os.environ["ENVIRONMENT"]
-production_env = os.environ["PRODUCTION_WORKSPACE"]
+production_env = os.environ["PRODUCTION_ENVIRONMENT"]
 ip_time_limit = os.environ["IP_TIME_LIMIT"]
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
   env                    = coalesce(var.environment, lower(terraform.workspace))
-  production_environment = coalesce(var.production_workspace, var.production_environment)
+  production_environment = coalesce(var.production_environment, var.production_workspace)
   takeover               = var.takeover == true && local.env == var.production_workspace ? true : false
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  env      = lower(terraform.workspace)
+  env      = var.environment != "" ? var.environment : lower(terraform.workspace)
   takeover = var.takeover == true && local.env == var.production_workspace ? true : false
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  env      = var.environment != "" ? var.environment : lower(terraform.workspace)
+  env      = coalesce(var.environment, lower(terraform.workspace))
   takeover = var.takeover == true && local.env == var.production_workspace ? true : false
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  env      = coalesce(var.environment, lower(terraform.workspace))
-  takeover = var.takeover == true && local.env == var.production_workspace ? true : false
+  env                    = coalesce(var.environment, lower(terraform.workspace))
+  production_environment = coalesce(var.production_workspace, var.production_environment)
+  takeover               = var.takeover == true && local.env == var.production_workspace ? true : false
 }

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "lambda-scan" {
   kms_arn                  = module.kms.kms_arn
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_workspace     = var.production_workspace
+  production_environment   = var.production_environment
   bugcrowd                 = var.bugcrowd
   bugcrowd_api_key         = var.bugcrowd_api_key
   bugcrowd_email           = var.bugcrowd_email
@@ -171,7 +171,7 @@ module "cloudwatch-event" {
   lambda_function_alias_names = module.lambda.lambda_function_alias_names
   schedule                    = var.reports_schedule
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_workspace ? var.update_schedule : var.update_schedule_nonprod
+  update_schedule             = local.env == var.production_environment ? var.update_schedule : var.update_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -185,7 +185,7 @@ module "resources-event" {
   lambda_function_alias_names = module.lambda-resources[0].lambda_function_alias_names
   schedule                    = var.reports_schedule
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_workspace ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -196,9 +196,9 @@ module "accounts-event" {
   lambda_function_arns        = module.lambda-accounts.lambda_function_arns
   lambda_function_names       = module.lambda-accounts.lambda_function_names
   lambda_function_alias_names = module.lambda-accounts.lambda_function_alias_names
-  schedule                    = local.env == var.production_workspace ? var.scan_schedule : var.scan_schedule_nonprod
+  schedule                    = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_workspace ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -236,7 +236,7 @@ module "lambda-cloudflare" {
   org_primary_account      = var.org_primary_account
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_workspace     = var.production_workspace
+  production_environment   = var.production_environment
   bugcrowd                 = var.bugcrowd
   bugcrowd_api_key         = var.bugcrowd_api_key
   bugcrowd_email           = var.bugcrowd_email
@@ -253,9 +253,9 @@ module "cloudflare-event" {
   lambda_function_arns        = module.lambda-cloudflare[0].lambda_function_arns
   lambda_function_names       = module.lambda-cloudflare[0].lambda_function_names
   lambda_function_alias_names = module.lambda-cloudflare[0].lambda_function_alias_names
-  schedule                    = local.env == var.production_workspace ? var.scan_schedule : var.scan_schedule_nonprod
+  schedule                    = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_workspace ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -337,7 +337,7 @@ module "lambda-scan-ips" {
   kms_arn                  = module.kms.kms_arn
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_workspace     = var.production_workspace
+  production_environment   = var.production_environment
   allowed_regions          = var.allowed_regions
   ip_time_limit            = var.ip_time_limit
   bugcrowd                 = var.bugcrowd
@@ -389,9 +389,9 @@ module "accounts-event-ips" {
   lambda_function_arns        = module.lambda-accounts-ips[0].lambda_function_arns
   lambda_function_names       = module.lambda-accounts-ips[0].lambda_function_names
   lambda_function_alias_names = module.lambda-accounts-ips[0].lambda_function_alias_names
-  schedule                    = local.env == var.production_workspace ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
+  schedule                    = local.env == var.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_workspace ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
+  update_schedule             = local.env == var.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,6 @@ module "lambda-scan" {
   kms_arn                  = module.kms.kms_arn
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_environment   = var.production_environment
   bugcrowd                 = var.bugcrowd
   bugcrowd_api_key         = var.bugcrowd_api_key
   bugcrowd_email           = var.bugcrowd_email
@@ -107,6 +106,7 @@ module "lambda-scan" {
   hackerone                = var.hackerone
   hackerone_api_token      = var.hackerone_api_token
   environment              = local.env
+  production_environment   = local.production_environment
 }
 
 module "lambda-takeover" {
@@ -171,7 +171,7 @@ module "cloudwatch-event" {
   lambda_function_alias_names = module.lambda.lambda_function_alias_names
   schedule                    = var.reports_schedule
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_environment ? var.update_schedule : var.update_schedule_nonprod
+  update_schedule             = local.env == local.production_environment ? var.update_schedule : var.update_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -185,7 +185,7 @@ module "resources-event" {
   lambda_function_alias_names = module.lambda-resources[0].lambda_function_alias_names
   schedule                    = var.reports_schedule
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -196,9 +196,9 @@ module "accounts-event" {
   lambda_function_arns        = module.lambda-accounts.lambda_function_arns
   lambda_function_names       = module.lambda-accounts.lambda_function_names
   lambda_function_alias_names = module.lambda-accounts.lambda_function_alias_names
-  schedule                    = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
+  schedule                    = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -236,7 +236,7 @@ module "lambda-cloudflare" {
   org_primary_account      = var.org_primary_account
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_environment   = var.production_environment
+  production_environment   = local.production_environment
   bugcrowd                 = var.bugcrowd
   bugcrowd_api_key         = var.bugcrowd_api_key
   bugcrowd_email           = var.bugcrowd_email
@@ -253,9 +253,9 @@ module "cloudflare-event" {
   lambda_function_arns        = module.lambda-cloudflare[0].lambda_function_arns
   lambda_function_names       = module.lambda-cloudflare[0].lambda_function_names
   lambda_function_alias_names = module.lambda-cloudflare[0].lambda_function_alias_names
-  schedule                    = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
+  schedule                    = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
+  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }
@@ -337,7 +337,7 @@ module "lambda-scan-ips" {
   kms_arn                  = module.kms.kms_arn
   sns_topic_arn            = module.sns.sns_topic_arn
   dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_environment   = var.production_environment
+  production_environment   = local.production_environment
   allowed_regions          = var.allowed_regions
   ip_time_limit            = var.ip_time_limit
   bugcrowd                 = var.bugcrowd
@@ -389,9 +389,9 @@ module "accounts-event-ips" {
   lambda_function_arns        = module.lambda-accounts-ips[0].lambda_function_arns
   lambda_function_names       = module.lambda-accounts-ips[0].lambda_function_names
   lambda_function_alias_names = module.lambda-accounts-ips[0].lambda_function_alias_names
-  schedule                    = local.env == var.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
+  schedule                    = local.env == local.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
   takeover                    = local.takeover
-  update_schedule             = local.env == var.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
+  update_schedule             = local.env == local.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
   update_lambdas              = var.update_lambdas
   environment                 = local.env
 }

--- a/terraform-modules/lambda-cloudflare/main.tf
+++ b/terraform-modules/lambda-cloudflare/main.tf
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "lambda" {
       PROJECT                  = var.project
       SNS_TOPIC_ARN            = var.sns_topic_arn
       ENVIRONMENT              = var.environment
-      PRODUCTION_WORKSPACE     = var.production_workspace
+      PRODUCTION_ENVIRONMENT   = var.production_environment
       BUGCROWD                 = var.bugcrowd
       BUGCROWD_API_KEY         = var.bugcrowd_api_key
       BUGCROWD_EMAIL           = var.bugcrowd_email

--- a/terraform-modules/lambda-cloudflare/variables.tf
+++ b/terraform-modules/lambda-cloudflare/variables.tf
@@ -11,7 +11,7 @@ variable "external_id" {}
 variable "org_primary_account" {}
 variable "sns_topic_arn" {}
 variable "dlq_sns_topic_arn" {}
-variable "production_workspace" {}
+variable "production_environment" {}
 variable "bugcrowd" {}
 variable "bugcrowd_api_key" {}
 variable "bugcrowd_email" {}

--- a/terraform-modules/lambda-scan-ips/main.tf
+++ b/terraform-modules/lambda-scan-ips/main.tf
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "lambda" {
       PROJECT                  = var.project
       SNS_TOPIC_ARN            = var.sns_topic_arn
       ENVIRONMENT              = var.environment
-      PRODUCTION_WORKSPACE     = var.production_workspace
+      PRODUCTION_ENVIRONMENT   = var.production_environment
       ALLOWED_REGIONS          = var.allowed_regions
       IP_TIME_LIMIT            = var.ip_time_limit
       BUGCROWD                 = var.bugcrowd

--- a/terraform-modules/lambda-scan-ips/variables.tf
+++ b/terraform-modules/lambda-scan-ips/variables.tf
@@ -10,7 +10,7 @@ variable "platform" {}
 variable "memory_size" {}
 variable "sns_topic_arn" {}
 variable "dlq_sns_topic_arn" {}
-variable "production_workspace" {}
+variable "production_environment" {}
 variable "allowed_regions" {}
 variable "ip_time_limit" {}
 variable "bugcrowd" {}

--- a/terraform-modules/lambda-scan/main.tf
+++ b/terraform-modules/lambda-scan/main.tf
@@ -52,7 +52,7 @@ resource "aws_lambda_function" "lambda" {
       PROJECT                  = var.project
       SNS_TOPIC_ARN            = var.sns_topic_arn
       ENVIRONMENT              = var.environment
-      PRODUCTION_WORKSPACE     = var.production_workspace
+      PRODUCTION_ENVIRONMENT   = var.production_environment
       BUGCROWD                 = var.bugcrowd
       BUGCROWD_API_KEY         = var.bugcrowd_api_key
       BUGCROWD_EMAIL           = var.bugcrowd_email

--- a/terraform-modules/lambda-scan/variables.tf
+++ b/terraform-modules/lambda-scan/variables.tf
@@ -10,7 +10,7 @@ variable "platform" {}
 variable "memory_size" {}
 variable "sns_topic_arn" {}
 variable "dlq_sns_topic_arn" {}
-variable "production_workspace" {}
+variable "production_environment" {}
 variable "bugcrowd" {}
 variable "bugcrowd_api_key" {}
 variable "bugcrowd_email" {}

--- a/variables.tf
+++ b/variables.tf
@@ -92,7 +92,7 @@ variable "environment" {
 
 variable "production_environment" {
   description = "Name of production environment - takeover is only turned on in this environment"
-  default     = "prd"
+  default     = ""
 }
 
 variable "production_workspace" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,13 +85,13 @@ variable "update_lambdas" {
   type        = list(any)
 }
 
-variable "environment" {
-  description = "Environment deploying to, defaults to terraform.workspace - optionally enter in tfvars file"
-  default     = ""
+variable "production_environment" {
+  description = "Name of production environment - takeover is only turned on in this environment"
+  default     = "prd"
 }
 
 variable "production_workspace" {
-  description = "Terraform workspace for production - takeover is only turned on in this environment"
+  description = "Deprecated, use production_environment. Will be removed in a future release"
   default     = "prd"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "update_lambdas" {
   type        = list(any)
 }
 
+variable "environment" {
+  description = "Environment deploying to, defaults to terraform.workspace - optionally enter in tfvars file"
+  default     = ""
+}
+
 variable "production_environment" {
   description = "Name of production environment - takeover is only turned on in this environment"
   default     = "prd"

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "update_lambdas" {
 }
 
 variable "environment" {
-  description = "Environment deploying to, defaults to workspace name - enter in tfvars file"
+  description = "Environment deploying to, defaults to terraform.workspace - optionally enter in tfvars file"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,11 @@ variable "update_lambdas" {
   type        = list(any)
 }
 
+variable "environment" {
+  description = "Environment deploying to, defaults to workspace name - enter in tfvars file"
+  default     = ""
+}
+
 variable "production_workspace" {
   description = "Terraform workspace for production - takeover is only turned on in this environment"
   default     = "prd"


### PR DESCRIPTION
Added:
- Environment variable to allow overriding `local.env`, for cases where `terraform.workspace` returns something not ideal.
- Included `setuptools` in prospector pre-commit check to fix `ModuleNotFoundError: No module named 'pkg_resources'`

Fixes #276