### PR TITLE
feat: reuse domain-protect as a reusable module instead of a copied root module

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,4 +1,0 @@
-terraform {
-  backend "s3" {
-  }
-}

--- a/provider.tf
+++ b/provider.tf
@@ -1,10 +1,3 @@
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}
-
 terraform {
   required_providers {
     aws = {
@@ -23,6 +16,5 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.1.0"
     }
-
   }
 }


### PR DESCRIPTION
## what
- feat: reuse domain-protect as a reusable module instead of a copied root module

## why
- This reduces the need to copy and paste or fork this repo in order to apply it

With this change and the removal of the dependence of a workspace in #281, we can now set something like this up

```hcl
provider aws {
  region = "us-east-2"
}

terraform {
  backend "s3" {
    bucket = "mybucket"
    key    = "path/to/my/key"
    region = "us-east-1"
  }
}

module "domain_protect" {
  for_each = toset([
    "dev",
    "prd",
  ]

  source = "git::https://github.com/domain-protect/domain-protect.git?ref=main"

  environment = each.key

  # input variables
}
```

## references
- Related to (but does not close) issue https://github.com/domain-protect/domain-protect/issues/277
- Related to PR https://github.com/domain-protect/domain-protect/pull/281
