### PR TITLE
feat: use upsteam module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ htmlcov
 
 #Testing
 .env
+.envrc

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "domain_protect" {
-  source = "git::https://github.com/domain-protect/terraform-aws-domain-protect.git?ref=v0.5.1"
+  source  = "domain-protect/domain-protect"
+  version = "0.5.1"
 
   project                  = var.project
   region                   = var.region

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "domain_protect" {
-  source = "git::https://github.com/domain-protect/terraform-aws-domain-protect.git?ref=v5"
+  source = "git::https://github.com/domain-protect/terraform-aws-domain-protect.git?ref=v0.5.1"
 
   project                  = var.project
   region                   = var.region

--- a/main.tf
+++ b/main.tf
@@ -1,414 +1,51 @@
-module "kms" {
-  source      = "./terraform-modules/kms"
-  project     = var.project
-  region      = var.region
-  environment = local.env
-}
+module "domain_protect" {
+  source = "git::https://github.com/domain-protect/terraform-aws-domain-protect.git?ref=v5"
 
-module "lambda-role" {
-  source                   = "./terraform-modules/iam"
   project                  = var.project
   region                   = var.region
+  org_primary_account      = var.org_primary_account
   security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "lambda-slack" {
-  source             = "./terraform-modules/lambda-slack"
-  runtime            = var.runtime
-  platform           = var.platform
-  memory_size        = var.memory_size_slack
-  project            = var.project
-  lambda_role_arn    = module.lambda-role.lambda_role_arn
-  kms_arn            = module.kms.kms_arn
-  sns_topic_arn      = module.sns.sns_topic_arn
-  dlq_sns_topic_arn  = module.sns-dead-letter-queue.sns_topic_arn
-  slack_channels     = local.env == "dev" ? var.slack_channels_dev : var.slack_channels
-  slack_webhook_urls = local.env == "dev" && length(var.slack_webhook_urls_dev) > 0 ? var.slack_webhook_urls_dev : var.slack_webhook_urls
-  slack_webhook_type = var.slack_webhook_type
-  slack_emoji        = var.slack_emoji
-  slack_fix_emoji    = var.slack_fix_emoji
-  slack_new_emoji    = var.slack_new_emoji
-  slack_username     = var.slack_username
-  environment        = local.env
-}
-
-module "lambda" {
-  source                   = "./terraform-modules/lambda"
+  external_id              = var.external_id
+  ip_time_limit            = var.ip_time_limit
+  reports_schedule         = var.reports_schedule
+  scan_schedule            = var.scan_schedule
+  scan_schedule_nonprod    = var.scan_schedule_nonprod
+  update_schedule          = var.update_schedule
+  update_schedule_nonprod  = var.update_schedule_nonprod
+  ip_scan_schedule         = var.ip_scan_schedule
+  ip_scan_schedule_nonprod = var.ip_scan_schedule_nonprod
+  stats_schedule           = var.stats_schedule
   lambdas                  = var.lambdas
+  takeover                 = var.takeover
+  update_lambdas           = var.update_lambdas
+  environment              = var.environment
+  production_environment   = var.production_environment
+  production_workspace     = var.production_workspace
   runtime                  = var.runtime
   platform                 = var.platform
   memory_size              = var.memory_size
-  project                  = var.project
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  lambda_role_arn          = module.lambda-role.lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  state_machine_arn        = module.step-function.state_machine_arn
-  allowed_regions          = var.allowed_regions
-  ip_time_limit            = var.ip_time_limit
-  environment              = local.env
-}
-
-module "lambda-accounts" {
-  source                   = "./terraform-modules/lambda-accounts"
-  lambdas                  = ["accounts"]
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  lambda_role_arn          = module.accounts-role.lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  state_machine_arn        = module.step-function.state_machine_arn
-  environment              = local.env
-}
-
-module "accounts-role" {
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  state_machine_arn        = module.step-function.state_machine_arn
-  policy                   = "accounts"
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "lambda-scan" {
-  source                   = "./terraform-modules/lambda-scan"
-  lambdas                  = ["scan"]
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  lambda_role_arn          = module.lambda-role.lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
+  memory_size_slack        = var.memory_size_slack
+  slack_channels           = var.slack_channels
+  slack_channels_dev       = var.slack_channels_dev
+  slack_webhook_urls       = var.slack_webhook_urls
+  slack_webhook_urls_dev   = var.slack_webhook_urls_dev
+  slack_webhook_type       = var.slack_webhook_type
+  slack_emoji              = var.slack_emoji
+  slack_fix_emoji          = var.slack_fix_emoji
+  slack_new_emoji          = var.slack_new_emoji
+  slack_username           = var.slack_username
   bugcrowd                 = var.bugcrowd
   bugcrowd_api_key         = var.bugcrowd_api_key
   bugcrowd_email           = var.bugcrowd_email
   bugcrowd_state           = var.bugcrowd_state
   hackerone                = var.hackerone
   hackerone_api_token      = var.hackerone_api_token
-  environment              = local.env
-  production_environment   = local.production_environment
-}
-
-module "lambda-takeover" {
-  #checkov:skip=CKV_AWS_274:role is ElasticBeanstalk admin, not full Administrator Access
-  count             = local.takeover ? 1 : 0
-  source            = "./terraform-modules/lambda-takeover"
-  runtime           = var.runtime
-  platform          = var.platform
-  memory_size       = var.memory_size_slack
-  project           = var.project
-  lambda_role_arn   = module.takeover-role.*.lambda_role_arn[0]
-  kms_arn           = module.kms.kms_arn
-  sns_topic_arn     = module.sns.sns_topic_arn
-  dlq_sns_topic_arn = module.sns-dead-letter-queue.sns_topic_arn
-  environment       = local.env
-}
-
-module "takeover-role" {
-  count                    = local.takeover ? 1 : 0
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  takeover                 = local.takeover
-  policy                   = "takeover"
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "lambda-resources" {
-  count             = local.takeover ? 1 : 0
-  source            = "./terraform-modules/lambda-resources"
-  lambdas           = ["resources"]
-  runtime           = var.runtime
-  memory_size       = var.memory_size_slack
-  project           = var.project
-  lambda_role_arn   = module.resources-role.*.lambda_role_arn[0]
-  kms_arn           = module.kms.kms_arn
-  sns_topic_arn     = module.sns.sns_topic_arn
-  dlq_sns_topic_arn = module.sns-dead-letter-queue.sns_topic_arn
-  environment       = local.env
-}
-
-module "resources-role" {
-  count                    = local.takeover ? 1 : 0
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  policy                   = "resources"
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "cloudwatch-event" {
-  source                      = "./terraform-modules/cloudwatch"
-  project                     = var.project
-  lambda_function_arns        = module.lambda.lambda_function_arns
-  lambda_function_names       = module.lambda.lambda_function_names
-  lambda_function_alias_names = module.lambda.lambda_function_alias_names
-  schedule                    = var.reports_schedule
-  takeover                    = local.takeover
-  update_schedule             = local.env == local.production_environment ? var.update_schedule : var.update_schedule_nonprod
-  update_lambdas              = var.update_lambdas
-  environment                 = local.env
-}
-
-module "resources-event" {
-  count                       = local.takeover ? 1 : 0
-  source                      = "./terraform-modules/cloudwatch"
-  project                     = var.project
-  lambda_function_arns        = module.lambda-resources[0].lambda_function_arns
-  lambda_function_names       = module.lambda-resources[0].lambda_function_names
-  lambda_function_alias_names = module.lambda-resources[0].lambda_function_alias_names
-  schedule                    = var.reports_schedule
-  takeover                    = local.takeover
-  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
-  update_lambdas              = var.update_lambdas
-  environment                 = local.env
-}
-
-module "accounts-event" {
-  source                      = "./terraform-modules/cloudwatch"
-  project                     = var.project
-  lambda_function_arns        = module.lambda-accounts.lambda_function_arns
-  lambda_function_names       = module.lambda-accounts.lambda_function_names
-  lambda_function_alias_names = module.lambda-accounts.lambda_function_alias_names
-  schedule                    = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
-  takeover                    = local.takeover
-  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
-  update_lambdas              = var.update_lambdas
-  environment                 = local.env
-}
-
-module "sns" {
-  source      = "./terraform-modules/sns"
-  project     = var.project
-  region      = var.region
-  kms_arn     = module.kms.kms_arn
-  environment = local.env
-}
-
-module "sns-dead-letter-queue" {
-  source            = "./terraform-modules/sns"
-  project           = var.project
-  region            = var.region
-  dead_letter_queue = true
-  kms_arn           = module.kms.kms_arn
-  environment       = local.env
-}
-
-module "lambda-cloudflare" {
-  count                    = var.cloudflare ? 1 : 0
-  source                   = "./terraform-modules/lambda-cloudflare"
-  lambdas                  = var.cloudflare_lambdas
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
+  cloudflare               = var.cloudflare
   cf_api_key               = var.cf_api_key
-  lambda_role_arn          = module.lambda-role.lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_environment   = local.production_environment
-  bugcrowd                 = var.bugcrowd
-  bugcrowd_api_key         = var.bugcrowd_api_key
-  bugcrowd_email           = var.bugcrowd_email
-  bugcrowd_state           = var.bugcrowd_state
-  hackerone                = var.hackerone
-  hackerone_api_token      = var.hackerone_api_token
-  environment              = local.env
-}
-
-module "cloudflare-event" {
-  count                       = var.cloudflare ? 1 : 0
-  source                      = "./terraform-modules/cloudwatch"
-  project                     = var.project
-  lambda_function_arns        = module.lambda-cloudflare[0].lambda_function_arns
-  lambda_function_names       = module.lambda-cloudflare[0].lambda_function_names
-  lambda_function_alias_names = module.lambda-cloudflare[0].lambda_function_alias_names
-  schedule                    = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
-  takeover                    = local.takeover
-  update_schedule             = local.env == local.production_environment ? var.scan_schedule : var.scan_schedule_nonprod
-  update_lambdas              = var.update_lambdas
-  environment                 = local.env
-}
-
-module "dynamodb" {
-  source      = "./terraform-modules/dynamodb"
-  project     = var.project
-  kms_arn     = module.kms.kms_arn
-  rcu         = var.rcu
-  wcu         = var.wcu
-  environment = local.env
-}
-
-module "step-function-role" {
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  policy                   = "state"
-  assume_role_policy       = "state"
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "step-function" {
-  source      = "./terraform-modules/step-function"
-  project     = var.project
-  lambda_arn  = module.lambda-scan.lambda_function_arns["scan"]
-  role_arn    = module.step-function-role.lambda_role_arn
-  kms_arn     = module.kms.kms_arn
-  environment = local.env
-}
-
-module "dynamodb-ips" {
-  count       = var.ip_address ? 1 : 0
-  source      = "./terraform-modules/dynamodb-ips"
-  project     = var.project
-  kms_arn     = module.kms.kms_arn
-  environment = local.env
-}
-
-module "step-function-ips" {
-  count       = var.ip_address ? 1 : 0
-  source      = "./terraform-modules/step-function"
-  project     = var.project
-  purpose     = "ips"
-  lambda_arn  = module.lambda-scan-ips[0].lambda_function_arns["scan-ips"]
-  role_arn    = module.step-function-role.lambda_role_arn
-  kms_arn     = module.kms.kms_arn
-  environment = local.env
-}
-
-module "lambda-role-ips" {
-  count                    = var.ip_address ? 1 : 0
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  policy                   = "lambda"
-  role_name                = "lambda-ips"
-  permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "lambda-scan-ips" {
-  count                    = var.ip_address ? 1 : 0
-  source                   = "./terraform-modules/lambda-scan-ips"
-  lambdas                  = ["scan-ips"]
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  lambda_role_arn          = module.lambda-role-ips[0].lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  production_environment   = local.production_environment
+  cloudflare_lambdas       = var.cloudflare_lambdas
+  rcu                      = var.rcu
+  wcu                      = var.wcu
+  ip_address               = var.ip_address
   allowed_regions          = var.allowed_regions
-  ip_time_limit            = var.ip_time_limit
-  bugcrowd                 = var.bugcrowd
-  bugcrowd_api_key         = var.bugcrowd_api_key
-  bugcrowd_email           = var.bugcrowd_email
-  bugcrowd_state           = var.bugcrowd_state
-  hackerone                = var.hackerone
-  hackerone_api_token      = var.hackerone_api_token
-  environment              = local.env
-}
-
-module "accounts-role-ips" {
-  count                    = var.ip_address ? 1 : 0
-  source                   = "./terraform-modules/iam"
-  project                  = var.project
-  region                   = var.region
-  security_audit_role_name = var.security_audit_role_name
-  kms_arn                  = module.kms.kms_arn
-  state_machine_arn        = module.step-function-ips[0].state_machine_arn
-  policy                   = "accounts"
-  role_name                = "accounts-ips"
   permissions_boundary_arn = var.permissions_boundary_arn
-  environment              = local.env
-}
-
-module "lambda-accounts-ips" {
-  count                    = var.ip_address ? 1 : 0
-  source                   = "./terraform-modules/lambda-accounts"
-  lambdas                  = ["accounts-ips"]
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  org_primary_account      = var.org_primary_account
-  lambda_role_arn          = module.accounts-role-ips[0].lambda_role_arn
-  kms_arn                  = module.kms.kms_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  state_machine_arn        = module.step-function-ips[0].state_machine_arn
-  environment              = local.env
-}
-
-module "accounts-event-ips" {
-  count                       = var.ip_address ? 1 : 0
-  source                      = "./terraform-modules/cloudwatch"
-  project                     = var.project
-  lambda_function_arns        = module.lambda-accounts-ips[0].lambda_function_arns
-  lambda_function_names       = module.lambda-accounts-ips[0].lambda_function_names
-  lambda_function_alias_names = module.lambda-accounts-ips[0].lambda_function_alias_names
-  schedule                    = local.env == local.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
-  takeover                    = local.takeover
-  update_schedule             = local.env == local.production_environment ? var.ip_scan_schedule : var.ip_scan_schedule_nonprod
-  update_lambdas              = var.update_lambdas
-  environment                 = local.env
-}
-
-module "lamdba-stats" {
-  source                   = "./terraform-modules/lambda-stats"
-  runtime                  = var.runtime
-  platform                 = var.platform
-  memory_size              = var.memory_size
-  project                  = var.project
-  kms_arn                  = module.kms.kms_arn
-  lambda_role_arn          = module.lambda-role.lambda_role_arn
-  sns_topic_arn            = module.sns.sns_topic_arn
-  dlq_sns_topic_arn        = module.sns-dead-letter-queue.sns_topic_arn
-  schedule_expression      = var.stats_schedule
-  org_primary_account      = var.org_primary_account
-  security_audit_role_name = var.security_audit_role_name
-  external_id              = var.external_id
-  environment              = local.env
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "domain_protect" {
-  source  = "domain-protect/domain-protect"
+  source  = "domain-protect/domain-protect/aws"
   version = "0.5.1"
 
   project                  = var.project

--- a/migrations.tf
+++ b/migrations.tf
@@ -1,0 +1,144 @@
+moved {
+  from = module.kms
+  to   = module.domain_protect.module.kms
+}
+
+moved {
+  from = module.lambda-role
+  to   = module.domain_protect.module.lambda_role
+}
+
+moved {
+  from = module.lambda-slack
+  to   = module.domain_protect.module.lambda_slack
+}
+
+moved {
+  from = module.lambda
+  to   = module.domain_protect.module.lambda
+}
+
+moved {
+  from = module.lambda-accounts
+  to   = module.domain_protect.module.lambda_accounts
+}
+
+moved {
+  from = module.accounts-role
+  to   = module.domain_protect.module.accounts_role
+}
+
+moved {
+  from = module.lambda-scan
+  to   = module.domain_protect.module.lambda_scan
+}
+
+moved {
+  from = module.lambda-takeover
+  to   = module.domain_protect.module.lambda_takeover
+}
+
+moved {
+  from = module.takeover-role
+  to   = module.domain_protect.module.takeover_role
+}
+
+moved {
+  from = module.lambda-resources
+  to   = module.domain_protect.module.lambda_resources
+}
+
+moved {
+  from = module.resources-role
+  to   = module.domain_protect.module.resources_role
+}
+
+moved {
+  from = module.cloudwatch-event
+  to   = module.domain_protect.module.cloudwatch_event
+}
+
+moved {
+  from = module.resources-event
+  to   = module.domain_protect.module.resources_event
+}
+
+moved {
+  from = module.accounts-event
+  to   = module.domain_protect.module.accounts_event
+}
+
+moved {
+  from = module.sns
+  to   = module.domain_protect.module.sns
+}
+
+moved {
+  from = module.sns-dead-letter-queue
+  to   = module.domain_protect.module.sns_dead_letter_queue
+}
+
+moved {
+  from = module.lambda-cloudflare
+  to   = module.domain_protect.module.lambda_cloudflare
+}
+
+moved {
+  from = module.cloudflare-event
+  to   = module.domain_protect.module.cloudflare_event
+}
+
+moved {
+  from = module.dynamodb
+  to   = module.domain_protect.module.dynamodb
+}
+
+moved {
+  from = module.step-function-role
+  to   = module.domain_protect.module.step_function_role
+}
+
+moved {
+  from = module.step-function
+  to   = module.domain_protect.module.step_function
+}
+
+moved {
+  from = module.dynamodb-ips
+  to   = module.domain_protect.module.dynamodb_ips
+}
+
+moved {
+  from = module.step-function-ips
+  to   = module.domain_protect.module.step_function_ips
+}
+
+moved {
+  from = module.lambda-role-ips
+  to   = module.domain_protect.module.lambda_role_ips
+}
+
+moved {
+  from = module.lambda-scan-ips
+  to   = module.domain_protect.module.lambda_scan_ips
+}
+
+moved {
+  from = module.accounts-role-ips
+  to   = module.domain_protect.module.accounts_role_ips
+}
+
+moved {
+  from = module.lambda-accounts-ips
+  to   = module.domain_protect.module.lambda_accounts_ips
+}
+
+moved {
+  from = module.accounts-event-ips
+  to   = module.domain_protect.module.accounts_event_ips
+}
+
+moved {
+  from = module.lamdba-stats
+  to   = module.domain_protect.module.lamdba_stats
+}

--- a/provider.tf
+++ b/provider.tf
@@ -9,11 +9,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.12.0"
+      version = "~> 5.12"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 2.2.0"
+      version = "~> 2.2"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
- [x] Use upstream module
- [x] Create a real version in upstream module `0.5.0`
- [x] Module registry
    - [x] Paul created a ticket with hashicorp as he was unable to publish it
    - [x] Upstream module should be published on hashicorp registry
    - [x] Upstream module should be published on opentofu registry: https://github.com/opentofu/registry/issues/999
    - [x] Use the proper `version` argument in the module instantiation

## why
- Single source of truth
- This will show the demarcation between domain-protect which is a root-module (aka root-dir or component) vs terraform-aws-domain-protect which is a reusable terraform module
- Tested locally to get the same plan in `dev` workspace with the original code as with the new module code
- Dropped `default_tags` from getting passed into upstream module since it is only used to configure the aws provider
- Two of the version pins needed to drop the patch version in order for `terraform init` to work without error

Generated terraform input vars via

```bash
rg 'variable "' -ttf variables.tf | cut -d'"' -f2 | while read v; do echo "$v = var.$v"; done
```

Generated `moved` blocks via

```bash
rg 'module "' -ttf main.tf | cut -d'"' -f2 | while read v; do echo "moved {\n  from = module.$v\n  to   = module.domain_protect.module.${v//-/_}\n}\n"; done
```

## references
- https://github.com/domain-protect/terraform-aws-domain-protect/releases/tag/v0.5.1
- https://registry.terraform.io/modules/domain-protect/domain-protect/aws/latest