### PR TITLE
Update scan.py to only generate aws credentials once

### DIFF
--- a/lambda_code/scan/scan.py
+++ b/lambda_code/scan/scan.py
@@ -2,6 +2,7 @@
 import json
 import os
 
+from utils.utils_aws import assume_role
 from utils.utils_aws import eb_susceptible
 from utils.utils_aws import get_cloudfront_s3_origin_takeover
 from utils.utils_aws import list_domains
@@ -290,12 +291,15 @@ def lambda_handler(event, context):  # pylint:disable=unused-argument
     account_id = event["Id"]
     account_name = event["Name"]
 
-    hosted_zones = list_hosted_zones(event)
+    boto3_session = assume_role(account_id)
+    route53 = boto3_session.client("route53")
+
+    hosted_zones = list_hosted_zones(event, route53)
 
     for hosted_zone in hosted_zones:
         print(f"Searching for vulnerable domain records in hosted zone {hosted_zone['Name']}")
 
-        record_sets = list_resource_record_sets(account_id, account_name, hosted_zone["Id"])
+        record_sets = list_resource_record_sets(account_id, account_name, hosted_zone["Id"], route53)
         record_sets = sanitise_wildcards(record_sets)
 
         alias_cloudfront_s3(account_name, record_sets, account_id)

--- a/utils/utils_aws.py
+++ b/utils/utils_aws.py
@@ -86,14 +86,15 @@ def list_accounts():
     return []
 
 
-def list_hosted_zones(account):
+def list_hosted_zones(account, route53):
 
     account_id = account["Id"]
     account_name = account["Name"]
 
     try:
-        boto3_session = assume_role(account_id)
-        route53 = boto3_session.client("route53")
+        if not route53:
+            boto3_session = assume_role(account_id)
+            route53 = boto3_session.client("route53")
 
         hosted_zones_list = []
 
@@ -119,11 +120,12 @@ def list_hosted_zones(account):
     return []
 
 
-def list_resource_record_sets(account_id, account_name, hosted_zone_id):
+def list_resource_record_sets(account_id, account_name, hosted_zone_id, route53):
 
     try:
-        boto3_session = assume_role(account_id)
-        route53 = boto3_session.client("route53")
+        if not route53:
+            boto3_session = assume_role(account_id)
+            route53 = boto3_session.client("route53")
 
         record_set_list = []
 


### PR DESCRIPTION
### Summary

Moving the route53 client generation code from utils_aws.py to scan.py, and then sending it as a parameter, resulted in a very large decrease in total runtime; by our calculations, the state machine went from timing out at 15 minutes regularly to taking 1-1.5 minutes. See the image below for reference.

![Step Functions Screenshot](https://github.com/user-attachments/assets/4ad2e704-23ff-4463-90d8-987329f8c200)

### Purpose

Here at Brightcove, we have a very large number of Route53 records spread across many hosted zones and AWS accounts. Starting a few months ago, we saw that the scan lambda was regularly failing. Troubleshooting showed that it was timing out on our of our largest accounts.

There weren't many options that already existed for tuning performance, so we had to look at the code instead. We noticed that this could be a potential improvement for runtime, and testing has showed it's been working well for us.

### Other Notes

As part of this, the `list_hosted_zones()` and `list_resource_record_sets()` functions were also updated to use an incoming AWS client. These functions are also used in `scan_ips.py`, but that module was **not** patched, as we were seeing very little delay with that code. The functions were updated to accept a client or generate one if none is presented, so this module should continue running as expected, and can easily be patched in the future to increase the speed and efficiency of scan_ips.py too.